### PR TITLE
Use PathBuf for paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 pub const VERSION_NUMBER: &str = env!("CARGO_PKG_VERSION");
@@ -22,8 +24,8 @@ pub struct Arguments {
     pub disable_banner: bool,
 
     /// Configuration file path
-    #[clap(short, long, default_value_t=String::from("./quibble.toml"))]
-    pub config: String,
+    #[clap(short, long, default_value="./quibble.toml")]
+    pub config: PathBuf,
 
     #[clap(subcommand)]
     pub commands: ArgumentCommands,
@@ -36,12 +38,12 @@ pub enum ArgumentCommands {
     /// Scan compose file(s)
     Compose {
         /// Folder or compose file path
-        #[clap(short, long, default_value_t=String::from("./"))]
-        path: String,
+        #[clap(short, long, default_value="./")]
+        path: PathBuf,
 
         /// Output Location
         #[clap(short, long)]
-        output: Option<String>,
+        output: Option<PathBuf>,
 
         /// Output Format
         #[clap(long, default_value_t=String::from("cli"))]

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Result};
 use log::{debug, warn};
-use std::{fmt::Display, path::Path};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
 pub mod rules;
 pub mod spec;
@@ -12,7 +15,7 @@ use walkdir::WalkDir;
 use crate::compose::ComposeSpec;
 
 pub struct ComposeFile {
-    pub path: String,
+    pub path: PathBuf,
     pub compose: ComposeSpec,
 }
 
@@ -58,7 +61,7 @@ pub fn find(path: &Path) -> Result<Vec<ComposeFile>> {
 
 impl Display for ComposeFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ComposeFile('{}')", self.path)
+        write!(f, "ComposeFile('{}')", self.path.display())
     }
 }
 
@@ -66,7 +69,7 @@ impl ComposeFile {
     pub fn parse(path: &Path) -> Result<Self> {
         match ComposeSpec::parse(path) {
             Ok(cs) => Ok(ComposeFile {
-                path: path.display().to_string(),
+                path: path.to_owned(),
                 compose: cs,
             }),
             Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,8 @@
-use std::{fs::canonicalize, path::Path, process};
+use std::{
+    fs::canonicalize,
+    path::{Path, PathBuf},
+    process,
+};
 
 use anyhow::Result;
 use clap::Parser;
@@ -21,7 +25,7 @@ fn output_cli(_config: &Config, severity: Severity, results: Vec<Alert>) -> Resu
     // If a single alert
     let mut alert_present: bool = false;
 
-    let mut current = String::new();
+    let mut current = PathBuf::new();
     for result in results {
         if severity < result.severity {
             debug!("Skipping: {}", result);
@@ -30,7 +34,7 @@ fn output_cli(_config: &Config, severity: Severity, results: Vec<Alert>) -> Resu
 
         if current != result.path.path && !result.path.path.is_empty() {
             println!("\n{:^32}\n", style(&result.path).bold().blue());
-            current = result.path.path.clone();
+            current = result.path.path;
         }
 
         let severity = match result.severity {
@@ -102,7 +106,7 @@ fn main() -> Result<()> {
 
             // Run the list of rules over the Compose File
             for cf in compose_files.iter() {
-                debug!("Compose File :: {}", cf.path);
+                debug!("Compose File :: {}", cf.path.display());
                 results.extend(rules.run(cf));
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,16 +25,16 @@ fn output_cli(_config: &Config, severity: Severity, results: Vec<Alert>) -> Resu
     // If a single alert
     let mut alert_present: bool = false;
 
-    let mut current = PathBuf::new();
+    let mut previous = PathBuf::new();
     for result in results {
         if severity < result.severity {
             debug!("Skipping: {}", result);
             continue;
         }
 
-        if current != result.path.path && !result.path.path.is_empty() {
+        if previous != result.path.path {
             println!("\n{:^32}\n", style(&result.path).bold().blue());
-            current = result.path.path;
+            previous = result.path.path;
         }
 
         let severity = match result.severity {

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-use std::{cell::RefCell, fmt::Display, ops::Index, rc::Rc};
+use std::{cell::RefCell, fmt::Display, ops::Index, path::PathBuf, rc::Rc};
 
 use anyhow::Result;
 use log::{error, warn};
@@ -150,7 +150,7 @@ impl Display for Alert {
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// Alert Location with a path and line number
 pub struct AlertLocation {
-    pub path: String,
+    pub path: PathBuf,
     pub line: Option<i32>,
 }
 
@@ -158,10 +158,10 @@ impl Display for AlertLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.line {
             Some(l) => {
-                write!(f, "{}#{}", self.path, l)
+                write!(f, "{}#{}", self.path.display(), l)
             }
             None => {
-                write!(f, "{}", self.path)
+                write!(f, "{}", self.path.display())
             }
         }
     }


### PR DESCRIPTION
Replaces uses of `String` with [`std::path::PathBuf`] in cases where a file system path is being represented.

[`std::path::PathBuf`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html