### PR TITLE
Use boxing for the Rules struct

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
             };
             debug!("Severity set :: {severity}");
 
-            let mut rules = Rules::new(&config);
+            let mut rules = Rules::new(config.clone());
             debug!("Rule count: {}", rules.len());
 
             // Run the list of rules over the Compose File

--- a/src/security.rs
+++ b/src/security.rs
@@ -193,14 +193,14 @@ impl Rules {
 
         if !rules.config.disable_rules {
             rules
-                .register(&rules::docker_version)
-                .register(&rules::docker_socket)
-                .register(&rules::docker_registry)
-                .register(&rules::container_images)
-                .register(&rules::kernel_parameters)
-                .register(&rules::security_opts)
-                .register(&rules::privileged)
-                .register(&rules::environment_variables);
+                .register(rules::docker_version)
+                .register(rules::docker_socket)
+                .register(rules::docker_registry)
+                .register(rules::container_images)
+                .register(rules::kernel_parameters)
+                .register(rules::security_opts)
+                .register(rules::privileged)
+                .register(rules::environment_variables);
         }
 
         rules

--- a/src/security.rs
+++ b/src/security.rs
@@ -222,8 +222,6 @@ impl Rules {
     where
         R: Fn(&Config, &ComposeFile, &mut Vec<Alert>) -> Result<()> + 'static,
     {
-        // let cell = Rc::new(RefCell::new(rule));
-        // self.rules.push(cell);
         self.rules.push(Box::new(rule));
         self
     }


### PR DESCRIPTION
Changed the `Rules` struct to use `Vec<Box<Rule>>` instead of `Vec<Rc<RefCell<&'rules Rule>>>`. This removes the need to worry about lifetimes.